### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.3.1
+
+Changes:
+- Dependencies updated
+  - `analyzer`: `>=3.2.0 <5.0.0` -> `>=4.3.0 <5.0.0`
+  - `build_runner`: `^2.0.4` -> `^2.2.0` 
+- Using `enclosingElement2` instead of `enclosingElement` (pub.dev score)
+- Added ignore rules for generated files
+  - `implementation_imports`
+  - `no_leading_underscores_for_library_prefixes`
+
 ## 2.3.0
 Features:
 - Added `tags` to the `Service` annotation 
@@ -34,7 +45,7 @@ Changes:
 Changes:
 - Dependencies updated
   - `analyzer`: `^3.2.0` -> `>=3.2.0 <5.0.0`
-  - `test`: `^1.20.1` -> `any´
+  - `test`: `^1.20.1` -> `any`
   - `source_gen` -> removed
 
 ## 2.2.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
     path: ../test/third_party_dependency
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.0.0
   build_runner: ^2.0.1

--- a/lib/src/builder/generator/service_provider/methods/try_resolve_internal.dart
+++ b/lib/src/builder/generator/service_provider/methods/try_resolve_internal.dart
@@ -15,7 +15,7 @@ final tryResolveInternalTemplate = cb.Method((m) {
     ..symbol = typeT.symbol
     ..isNullable = true);
 
-  var exposedType$ = cb.refer('_exposedType');
+  var exposedType$ = cb.refer('exposedType');
   var instance$ = cb.refer('instance');
 
   var typeP = cb.refer('t');

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -175,7 +175,7 @@ class PreflightBuilder implements Builder {
                 .toString()
                 .startsWith('package:catalyst_builder/src/annotation/') ??
             false) &&
-        annotation.element?.enclosingElement?.name == name;
+        annotation.element?.enclosingElement2?.name == name;
   }
 
   List<String> _getTags(DartObject? serviceAnnotation) {

--- a/lib/src/builder/service_provider_builder.dart
+++ b/lib/src/builder/service_provider_builder.dart
@@ -61,7 +61,7 @@ class ServiceProviderBuilder implements Builder {
           buildServiceProviderClass(config, services),
         ])).accept(emitter).toString();
     final content = DartFormatter().format('''
-// ignore_for_file: prefer_relative_imports, public_member_api_docs
+// ignore_for_file: prefer_relative_imports, public_member_api_docs, implementation_imports, no_leading_underscores_for_library_prefixes
 $rawOutput
 ''');
     await buildStep.writeAsString(_outputAsset(buildStep), content);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,10 @@ dependencies:
   build: ^2.1.0
   glob: ^2.1.0
   path: ^1.8.0
-  analyzer: '>=3.2.0 <5.0.0'
+  analyzer: '>=4.3.0 <5.0.0'
   build_runner_core: ^7.1.0
 
 dev_dependencies:
   test: any
-  build_runner: ^2.0.4
+  build_runner: ^2.2.0
   lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: catalyst_builder
 description: A dependency injection provider builder for dart. Easy to use and lightweight af.
-version: 2.3.0
+version: 2.3.1
 homepage: 'https://github.com/mintware-de/catalyst_builder'
 repository: 'https://github.com/mintware-de/catalyst_builder'
 


### PR DESCRIPTION
- renamed local var `_exposedType` to `exposedType`
- Upgraded dart analyzer to >= 4.3.0
- Using `enclosingElement2` instead of `enclosingElement` (pub.dev score)
- Added ignore rules for generated files
- Upgraded the build_runner to ^2.2.0