### PR TITLE
V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.0.0
+
+Features:
+- Added the `GenerateServiceProvider` annotation
+
+Changes:
+- Updated the minimum Dart SDK version to `2.17.0`
+
+Breaking Changes:
+- `build.yaml`
+  - Removed the option `outputName`
+    This change was necessary since the build_runner does not recognize changes correctly with runtime file names.
+  - Removed the option `preflightExtension`.
+
 ## 2.3.1
 
 Changes:

--- a/README.md
+++ b/README.md
@@ -39,19 +39,39 @@ Decorate your services with `@Service`:
 class MyService {}
 ```
 
+Decorate in your entry point file any top level symbol with `@GenerateServiceProvider`:
+```dart
+// my_entrypoint.dart
+
+import 'package:catalyst_builder/catalyst_builder.dart';
+
+@GenerateServiceProvider()
+void main() {
+  // ...
+}
+```
+
 Then run `pub run build_runner build` or `flutter pub run build_runner build`. <br>
 You can also run `pub run build_runner watch` or `flutter pub run build_runner watch` to update the provider
 automatically as you perform changes.
 
-You should see a new file `service_provider.dart` after the build. Import it to use the service provider.
+You should see a new file `*.catalyst_builder.g.dart` after the build. Import it to use the service provider.
 
 ```dart
-import 'default_service_provider.dart';
+// my_entrypoint.dart
 
+// Import the service provider 
+import 'my_entrypoint.catalyst_builder.g.dart';
+
+@GenerateServiceProvider()
 void main() {
+  // Create a new instance of the service provider
   var provider = DefaultServiceProvider();
+  
+  // Boot it to wire services
   provider.boot();
 
+  // Resolve a service.
   var myService1 = provider.resolve<MyService>();
 
   // Inferred types are also supported
@@ -297,6 +317,5 @@ targets:
       catalyst_builder|buildServiceProvider:
         options:
           providerClassName: 'DefaultServiceProvider' # class name of the provider
-          outputName: 'default_service_provider.dart' # file name of the provider. (Can also contain /)
           includePackageDependencies: false # True if services from dependencies should be added to your service provider (v1.1.0+)
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,33 @@
+# Upgrade from v2 to v3
+
+## Changes in `build.yaml`
+
+The options `preflightExtension` and `outputName` has been removed.
+
+```diff
+# build.yaml
+targets:
+  $default:
+    auto_apply_builders: true
+    builders:
+      catalyst_builder|preflight:
+        options:
+-           preflightExtension: '.catalyst_builder.preflight.json'
+      catalyst_builder|buildServiceProvider:
+        options:
+            providerClassName: 'ExampleProvider'
+-           outputName: 'src/example.container.dart'
+            includePackageDependencies: true
+```
+
+To generate the service provider you've to use the new `@GenerateServiceProvider` annotation.
+This annotation will create a `*.example.catalyst_builder.g.dart` when running the build runner.
+
+```diff
+ import 'package:catalyst_builder/catalyst_builder.dart';
+-import './src/example.container.dart';
++import 'example.catalyst_builder.g.dart';
+
++@GenerateServiceProvider()
+ void main() {}
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,17 +1,1 @@
-include: 'package:lints/recommended.yaml'
-
-linter:
-  rules:
-    - avoid_print
-    - avoid_unnecessary_containers
-    - avoid_web_libraries_in_flutter
-    - no_logic_in_create_state
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - sized_box_for_whitespace
-    - sort_child_properties_last
-    - use_build_context_synchronously
-    - use_full_hex_values_for_flutter_colors
-    - use_key_in_widget_constructors
+include: package:lints/recommended.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -6,15 +6,12 @@ builders:
     build_extensions: { '.dart': [ '.catalyst_builder.preflight.json' ] }
     build_to: cache
     auto_apply: dependents
-    defaults:
-      options:
-        preflightExtension: '.catalyst_builder.preflight.json'
 
   buildServiceProvider:
     import: 'package:catalyst_builder/src/builder/service_provider_builder.dart'
     builder_factories:
       - 'buildServiceProvider'
-    build_extensions: { '$lib$': [ ] }
+    build_extensions: { '.dart': [ '.catalyst_builder.g.dart' ] }
     build_to: source
     auto_apply: dependents
     required_inputs:
@@ -22,6 +19,4 @@ builders:
     defaults:
       options:
         providerClassName: 'DefaultServiceProvider'
-        outputName: 'default_service_provider.dart'
         includePackageDependencies: false
-        preflightExtension: '.catalyst_builder.preflight.json'

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -4,4 +4,4 @@
 
 # Conventional directory for build output.
 build/
-lib/src/example.container.dart
+*.g.dart

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,16 +1,1 @@
-include: 'package:lints/recommended.yaml'
-
-linter:
-  rules:
-    - avoid_unnecessary_containers
-    - avoid_web_libraries_in_flutter
-    - no_logic_in_create_state
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - sized_box_for_whitespace
-    - sort_child_properties_last
-    - use_build_context_synchronously
-    - use_full_hex_values_for_flutter_colors
-    - use_key_in_widget_constructors
+include: ../analysis_options.yaml

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -5,5 +5,4 @@ targets:
       catalyst_builder|buildServiceProvider:
         options:
           providerClassName: 'ExampleProvider'
-          outputName: 'src/example.container.dart'
           includePackageDependencies: true

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -6,7 +6,6 @@ import './src/manually_wired_service.dart';
 
 export './src/chat_provider.dart';
 export './src/cool_chat_provider.dart';
-export './src/example.container.dart';
 export './src/manually_wired_service.dart';
 export './src/preload_service.dart';
 export './src/singleton_service.dart';
@@ -14,7 +13,10 @@ export './src/transient_service.dart';
 export './src/transport.dart';
 export './src/self_registered_service.dart';
 
+export 'example.catalyst_builder.g.dart';
+
 @Preload()
+@GenerateServiceProvider()
 @ServiceMap(services: {
   ManuallyWiredServiceImplementation: Service(
     exposeAs: ManuallyWiredService,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   catalyst_builder:

--- a/lib/src/annotation/annotation.dart
+++ b/lib/src/annotation/annotation.dart
@@ -1,3 +1,4 @@
+export 'generate_service_provider.dart';
 export 'parameter.dart';
 export 'preload.dart';
 export 'service.dart';

--- a/lib/src/annotation/generate_service_provider.dart
+++ b/lib/src/annotation/generate_service_provider.dart
@@ -1,0 +1,4 @@
+/// Mark the file which contains this annotation as the entry point.
+class GenerateServiceProvider {
+  const GenerateServiceProvider();
+}

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -106,12 +106,12 @@ class PreflightBuilder implements Builder {
   }
 
   SymbolReference? _getExposeAs(DartObject? serviceAnnotation) {
-    var typeValue = serviceAnnotation?.getField('exposeAs')?.toTypeValue();
-    if (typeValue is! InterfaceType) {
+    var typed = serviceAnnotation?.getField('exposeAs')?.toTypeValue();
+    if (typed is! InterfaceType) {
       return null;
     }
 
-    var exposeAsElement = typeValue.element2;
+    var exposeAsElement = typed.element2;
 
     return SymbolReference(
       symbolName: exposeAsElement.name,

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 
 import '../../catalyst_builder.dart';
@@ -11,11 +12,6 @@ import 'dto/dto.dart';
 /// The PreflightBuilder scans the files for @Service annotations.
 /// The result is stored in preflight.json files.
 class PreflightBuilder implements Builder {
-  final Map<String, dynamic> _config;
-
-  /// PreflightBuilder constructor
-  PreflightBuilder(this._config);
-
   @override
   FutureOr<void> build(BuildStep buildStep) async {
     if (!await buildStep.resolver.isLibrary(buildStep.inputId)) {
@@ -25,7 +21,7 @@ class PreflightBuilder implements Builder {
     final entryLib = await buildStep.inputLibrary;
 
     final preflightAsset =
-        buildStep.inputId.changeExtension(_config['preflightExtension']);
+        buildStep.inputId.changeExtension('.catalyst_builder.preflight.json');
     var extractedAnnotations = await _extractAnnotations(entryLib);
 
     await buildStep.writeAsString(
@@ -37,7 +33,7 @@ class PreflightBuilder implements Builder {
   @override
   Map<String, List<String>> get buildExtensions => {
         r'$lib$': [],
-        '.dart': [_config['preflightExtension']],
+        '.dart': ['.catalyst_builder.preflight.json'],
       };
 
   Future<PreflightPart> _extractAnnotations(LibraryElement entryLib) async {
@@ -52,8 +48,13 @@ class PreflightBuilder implements Builder {
           var serviceMap =
               serviceMapAnnotation?.getField('services')?.toMapValue() ?? {};
           for (var kvp in serviceMap.entries) {
-            var keyElement = kvp.key?.toTypeValue()?.element;
-            if (keyElement == null || keyElement is! ClassElement) {
+            var typed = kvp.key?.toTypeValue();
+            if (typed is! InterfaceType) {
+              continue;
+            }
+
+            var keyElement = typed.element2;
+            if (keyElement is! ClassElement) {
               continue;
             }
 
@@ -105,17 +106,17 @@ class PreflightBuilder implements Builder {
   }
 
   SymbolReference? _getExposeAs(DartObject? serviceAnnotation) {
-    var exposeAsElement =
-        serviceAnnotation?.getField('exposeAs')?.toTypeValue()?.element;
-
-    SymbolReference? exposeAs;
-    if (exposeAsElement != null) {
-      exposeAs = SymbolReference(
-        symbolName: exposeAsElement.name!,
-        library: exposeAsElement.librarySource?.uri.toString(),
-      );
+    var typeValue = serviceAnnotation?.getField('exposeAs')?.toTypeValue();
+    if (typeValue is! InterfaceType) {
+      return null;
     }
-    return exposeAs;
+
+    var exposeAsElement = typeValue.element2;
+
+    return SymbolReference(
+      symbolName: exposeAsElement.name,
+      library: exposeAsElement.librarySource.uri.toString(),
+    );
   }
 
   ServiceLifetime _getLifetimeFromAnnotation(DartObject? serviceAnnotation) {
@@ -175,7 +176,7 @@ class PreflightBuilder implements Builder {
                 .toString()
                 .startsWith('package:catalyst_builder/src/annotation/') ??
             false) &&
-        annotation.element?.enclosingElement2?.name == name;
+        annotation.element?.enclosingElement3?.name == name;
   }
 
   List<String> _getTags(DartObject? serviceAnnotation) {
@@ -195,5 +196,4 @@ class PreflightBuilder implements Builder {
 }
 
 /// Runs the preflight builder
-Builder runPreflight(BuilderOptions options) =>
-    PreflightBuilder(options.config);
+Builder runPreflight(BuilderOptions options) => PreflightBuilder();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,22 +1,22 @@
 name: catalyst_builder
-description: A dependency injection provider builder for dart. Easy to use and lightweight af.
-version: 2.3.1
+description: A lightweight and easy to use dependency injection provider builder for dart.
+version: 3.0.0
 homepage: 'https://github.com/mintware-de/catalyst_builder'
 repository: 'https://github.com/mintware-de/catalyst_builder'
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  code_builder: ^4.1.0
+  code_builder: ^4.2.0
   dart_style: ^2.0.1
   build: ^2.1.0
   glob: ^2.1.0
   path: ^1.8.0
-  analyzer: '>=4.3.0 <5.0.0'
+  analyzer: '>=4.4.0 <5.0.0'
   build_runner_core: ^7.1.0
+  lints: ^2.0.0
 
 dev_dependencies:
   test: any
   build_runner: ^2.2.0
-  lints: ^2.0.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,12 +2,10 @@
 set -e
 
 cd ./example
-#dart pub get
-rm -f lib/src/example.container.dart
 dart run build_runner build --delete-conflicting-outputs
-cat "lib/src/example.container.dart" \
-    | sed -e "s+package\:catalyst_builder_example\/src\/++g;" \
-    | sed -e "s+package\:third_party_dependency\/+\.\.\/\.\.\/\.\.\/test\/third_party_dependency\/lib\/+g;w lib/src/example.container.dart"
+cat "lib/example.catalyst_builder.g.dart" \
+    | sed -e "s+package\:catalyst_builder_example\/+./+g;" \
+    | sed -e "s+package\:third_party_dependency\/+\.\.\/\.\.\/test\/third_party_dependency\/lib\/+g;w lib/example.catalyst_builder.g.dart"
 cd ..
 
 dart run test

--- a/test/unit/annotation/generate_service_provider_test.dart
+++ b/test/unit/annotation/generate_service_provider_test.dart
@@ -1,0 +1,9 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('exists', () {
+    var annotation = const GenerateServiceProvider();
+    expect(annotation, const TypeMatcher<GenerateServiceProvider>());
+  });
+}

--- a/test/unit/annotation/service_test.dart
+++ b/test/unit/annotation/service_test.dart
@@ -15,9 +15,10 @@ void main() {
     expect(serviceWithLifetime.tags, isEmpty);
 
     const serviceWithAdditionalProperties = Service(
-        lifetime: ServiceLifetime.transient,
-        exposeAs: String,
-        tags: [#tag1, #tag2]);
+      lifetime: ServiceLifetime.transient,
+      exposeAs: String,
+      tags: [#tag1, #tag2],
+    );
     expect(serviceWithAdditionalProperties.exposeAs, const TypeMatcher<Type>());
     expect(serviceWithAdditionalProperties.exposeAs, equals(String));
     expect(serviceWithAdditionalProperties.lifetime, ServiceLifetime.transient);

--- a/test/unit/annotation/service_test.dart
+++ b/test/unit/annotation/service_test.dart
@@ -15,10 +15,9 @@ void main() {
     expect(serviceWithLifetime.tags, isEmpty);
 
     const serviceWithAdditionalProperties = Service(
-      lifetime: ServiceLifetime.transient,
-      exposeAs: String,
-      tags: [#tag1, #tag2]
-    );
+        lifetime: ServiceLifetime.transient,
+        exposeAs: String,
+        tags: [#tag1, #tag2]);
     expect(serviceWithAdditionalProperties.exposeAs, const TypeMatcher<Type>());
     expect(serviceWithAdditionalProperties.exposeAs, equals(String));
     expect(serviceWithAdditionalProperties.lifetime, ServiceLifetime.transient);

--- a/test/unit/exception/catalyst_builder_exception_test.dart
+++ b/test/unit/exception/catalyst_builder_exception_test.dart
@@ -16,15 +16,17 @@ void main() {
   });
 
   test('toString', () {
-
     var inner = _Tmp('bar');
     var inner2 = _Tmp('baz', inner);
     var ex = _Tmp('foo', inner2);
     expect(inner.toString(), equals('CatalystBuilderException: bar'));
-    expect(ex.toString(), equals('''
+    expect(
+        ex.toString(),
+        equals('''
 CatalystBuilderException: foo
 \tInner Exception: baz
 \t\tInner Exception: bar
-'''.trim()));
+'''
+            .trim()));
   });
 }

--- a/test/unit/exception/catalyst_builder_exception_test.dart
+++ b/test/unit/exception/catalyst_builder_exception_test.dart
@@ -21,12 +21,13 @@ void main() {
     var ex = _Tmp('foo', inner2);
     expect(inner.toString(), equals('CatalystBuilderException: bar'));
     expect(
-        ex.toString(),
-        equals('''
+      ex.toString(),
+      equals('''
 CatalystBuilderException: foo
 \tInner Exception: baz
 \t\tInner Exception: bar
 '''
-            .trim()));
+          .trim()),
+    );
   });
 }


### PR DESCRIPTION
Features:
- Added the `GenerateServiceProvider` annotation

Changes:
- Updated the minimum Dart SDK version to `2.17.0`

Breaking Changes:
- `build.yaml`
  - Removed the option `outputName`
    This change was necessary since the build_runner does not recognize changes correctly with runtime file names.
  - Removed the option `preflightExtension`.


Upgrade guide see [UPGRADE.md](https://github.com/mintware-de/catalyst_builder/blob/bcbfa5b2538152ceb27482ab2bfe851b435cc0bd/UPGRADE.md)