### PR TITLE
Inject annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Features:
 - Introducing the new `@Inject` annotation. This annotation works like the `@Parameter` Annotation but is more flexible.
-  You can use it to inject a list of tagged services and also to inject parameters.
+  You can use it to inject a list of tagged services and also to inject parameters. The example code contains a
+  example for this feature.
 
 Deprecations:
 - The `@Parameter` annotation was marked as deprecated and will be removed in the next major release.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 3.2.0
 
+Features:
+- Introducing the new `@Inject` annotation. This annotation works like the `@Parameter` Annotation but is more flexible.
+  You can use it to inject a list of tagged services and also to inject parameters.
+
+Deprecations:
+- The `@Parameter` annotation was marked as deprecated and will be removed in the next major release.  
+  See [UPGRADE.md](UPGRADE.md) for upgrade instructions.
+
 Changes:
 - Updated the minimum `analyzer` version to `^5.0.0`
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,29 @@ void main() {
 
 ```
 
+## Inject tagged services (v3.2.0+)
+
+The `@Inject` annotation allows you to inject a list of services tagged with a certain tag.
+```dart
+abstract class MyServiceBase {}
+
+@Service(tags: [#groupTag, #anotherTag])
+class MyService1 extends MyServiceBase {}
+
+@Service(tags: [#groupTag, #anotherDifferentTag])
+class MyService2 extends MyServiceBase {}
+
+@Service()
+class ServiceWithDeps {
+  
+  ServiceWithDeps(
+      @Inject(tag: #groupTag) List<MyServiceBase> services,
+  ) {
+    // services includes MyService1 and MyService2
+  }
+}
+
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ void main() {
 }
 ```
 
+> The `@Parameter` annotation is deprecated since v3.2.0 and will be removed in v4. Use `@Inject(parameter: 'name')` instead.  
+
+
 ## Service Maps (v1.2.0+)
 
 If you depend on a third party package, you can not easily add the `@Service` to classes inside the package.
@@ -304,6 +307,7 @@ void main() {
 }
 
 ```
+
 
 ## Configuration
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade from v3 to v4
+
+## @Parameter annotation removed
+The `@Parameter('name')` annotation was removed. You can use `@Inject(parameter: 'name')` instead.
+
+A simple replace-all `@Parameter(` with `@Inject(parameter: ` should fix your code.
+
 # Upgrade from v2 to v3
 
 ## Changes in `build.yaml`

--- a/example/bin/catalyst_builder_example.dart
+++ b/example/bin/catalyst_builder_example.dart
@@ -24,4 +24,7 @@ void main(List<String> arguments) {
   for (var svc in servicesByTag) {
     print(svc);
   }
+
+  var broadcaster = provider.resolve<Broadcaster>();
+  broadcaster.sendChatMessage('Hello Broadcast using injection tag.');
 }

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -12,6 +12,7 @@ export './src/singleton_service.dart';
 export './src/transient_service.dart';
 export './src/transport.dart';
 export './src/self_registered_service.dart';
+export './src/broadcaster.dart';
 
 export 'example.catalyst_builder.g.dart';
 

--- a/example/lib/src/broadcaster.dart
+++ b/example/lib/src/broadcaster.dart
@@ -1,0 +1,24 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
+
+import './transport.dart';
+import 'chat_provider.dart';
+
+@Service()
+class Broadcaster implements ChatProvider {
+  List<Transport> transports;
+
+  Broadcaster(
+    @Inject(tag: #transport) this.transports,
+  );
+
+  @override
+  Future<void> sendChatMessage(String message) async {
+    for (var transport in transports) {
+      print('Sending to ${transport.runtimeType}');
+      transport.transferData(message);
+    }
+  }
+
+  @override
+  String get username => 'Broadcaster User';
+}

--- a/example/lib/src/cool_chat_provider.dart
+++ b/example/lib/src/cool_chat_provider.dart
@@ -15,7 +15,7 @@ class CoolChatProvider implements ChatProvider {
 
   CoolChatProvider({
     required this.transport,
-    @Parameter('sender_username') required this.username,
+    @Inject(parameter: 'sender_username') required this.username,
   });
 
   @override

--- a/example/lib/src/transport.dart
+++ b/example/lib/src/transport.dart
@@ -18,7 +18,6 @@ class ConsoleTransport implements Transport {
   }
 }
 
-
 @Service(
   tags: [#chat, #transport],
 )

--- a/example/lib/src/transport.dart
+++ b/example/lib/src/transport.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:catalyst_builder/catalyst_builder.dart';
 
 abstract class Transport {
@@ -13,5 +15,17 @@ class ConsoleTransport implements Transport {
   void transferData(String data) {
     print('**Sending through console**');
     print(data);
+  }
+}
+
+
+@Service(
+  tags: [#chat, #transport],
+)
+class HttpTransport implements Transport {
+  @override
+  void transferData(String data) {
+    print('**Sending over http**');
+    print(base64Encode(data.codeUnits));
   }
 }

--- a/lib/src/annotation/annotation.dart
+++ b/lib/src/annotation/annotation.dart
@@ -1,4 +1,5 @@
 export 'generate_service_provider.dart';
+export 'inject.dart';
 export 'parameter.dart';
 export 'preload.dart';
 export 'service.dart';

--- a/lib/src/annotation/inject.dart
+++ b/lib/src/annotation/inject.dart
@@ -1,3 +1,5 @@
+import '../service_provider.dart';
+
 /// Inject a specific parameter or a list of services with a specific tag.
 /// You can only use one property.
 class Inject {
@@ -5,6 +7,12 @@ class Inject {
   /// If no services are tagged with the tag, an empty list will be injected.
   final Symbol? tag;
 
+  /// The name of the bound parameter inside [ServiceProvider.parameters].
+  final String? parameter;
+
   /// Creates a new inject annotation.
-  const Inject({this.tag});
+  const Inject({
+    this.tag,
+    this.parameter,
+  });
 }

--- a/lib/src/annotation/inject.dart
+++ b/lib/src/annotation/inject.dart
@@ -1,0 +1,10 @@
+/// Inject a specific parameter or a list of services with a specific tag.
+/// You can only use one property.
+class Inject {
+  /// If [tag] is set, the provider will inject an array with all services with the given tag.
+  /// If no services are tagged with the tag, an empty list will be injected.
+  final Symbol? tag;
+
+  /// Creates a new inject annotation.
+  const Inject({this.tag});
+}

--- a/lib/src/annotation/parameter.dart
+++ b/lib/src/annotation/parameter.dart
@@ -1,6 +1,7 @@
 import '../service_provider.dart';
 
 /// Provide an alternative parameter binding
+@Deprecated('Use @Inject(parameter: "name") instead.')
 class Parameter {
   /// The [name] of the bound parameter inside [ServiceProvider.parameters].
   final String name;

--- a/lib/src/annotation/parameter.dart
+++ b/lib/src/annotation/parameter.dart
@@ -1,4 +1,4 @@
-import '../../catalyst_builder.dart';
+import '../service_provider.dart';
 
 /// Provide an alternative parameter binding
 class Parameter {

--- a/lib/src/builder/dto/constructor_arg.dart
+++ b/lib/src/builder/dto/constructor_arg.dart
@@ -17,9 +17,7 @@ class ConstructorArg {
   /// True if the parameter is a named parameter.
   final bool isNamed;
 
-  /// Overwrite the default parameter name
-  final String? boundParameter;
-
+  /// The extracted Inject annotation.
   final InjectAnnotation? inject;
 
   /// Create a ConstructorArg.
@@ -29,7 +27,6 @@ class ConstructorArg {
     required this.isOptional,
     required this.isPositional,
     required this.isNamed,
-    required this.boundParameter,
     required this.inject,
   });
 
@@ -41,7 +38,6 @@ class ConstructorArg {
       isOptional: json['isOptional'],
       isPositional: json['isPositional'],
       isNamed: json['isNamed'],
-      boundParameter: json['boundParameter'],
       inject: json['inject'] != null
           ? InjectAnnotation.fromJson(json['inject'])
           : null,
@@ -56,7 +52,6 @@ class ConstructorArg {
       'isNamed': isNamed,
       'isPositional': isPositional,
       'defaultValue': defaultValue,
-      'boundParameter': boundParameter,
       'inject': inject?.toJson(),
     };
   }

--- a/lib/src/builder/dto/constructor_arg.dart
+++ b/lib/src/builder/dto/constructor_arg.dart
@@ -1,3 +1,5 @@
+import 'inject_annotation.dart';
+
 /// Represents an argument in the constructor
 class ConstructorArg {
   /// The name of the argument
@@ -18,6 +20,8 @@ class ConstructorArg {
   /// Overwrite the default parameter name
   final String? boundParameter;
 
+  final InjectAnnotation? inject;
+
   /// Create a ConstructorArg.
   const ConstructorArg({
     required this.name,
@@ -26,6 +30,7 @@ class ConstructorArg {
     required this.isPositional,
     required this.isNamed,
     required this.boundParameter,
+    required this.inject,
   });
 
   /// Creates a new instance from the result of [toJson].
@@ -37,6 +42,9 @@ class ConstructorArg {
       isPositional: json['isPositional'],
       isNamed: json['isNamed'],
       boundParameter: json['boundParameter'],
+      inject: json['inject'] != null
+          ? InjectAnnotation.fromJson(json['inject'])
+          : null,
     );
   }
 
@@ -49,6 +57,7 @@ class ConstructorArg {
       'isPositional': isPositional,
       'defaultValue': defaultValue,
       'boundParameter': boundParameter,
+      'inject': inject?.toJson(),
     };
   }
 }

--- a/lib/src/builder/dto/dto.dart
+++ b/lib/src/builder/dto/dto.dart
@@ -1,4 +1,5 @@
 export 'constructor_arg.dart';
 export 'extracted_service.dart';
+export 'inject_annotation.dart';
 export 'preflight_part.dart';
 export 'symbol_reference.dart';

--- a/lib/src/builder/dto/inject_annotation.dart
+++ b/lib/src/builder/dto/inject_annotation.dart
@@ -1,0 +1,22 @@
+/// Represents the extracted Inject annotation
+class InjectAnnotation {
+  final String? tag;
+
+  const InjectAnnotation({
+    this.tag,
+  });
+
+  /// Creates a new instance from the result of [toJson].
+  factory InjectAnnotation.fromJson(Map<String, dynamic> json) {
+    return InjectAnnotation(
+      tag: json['tag'],
+    );
+  }
+
+  /// Dumps the object in a map that can be used in [InjectAnnotation.fromJson].
+  Map<String, dynamic> toJson() {
+    return {
+      'tag': tag,
+    };
+  }
+}

--- a/lib/src/builder/dto/inject_annotation.dart
+++ b/lib/src/builder/dto/inject_annotation.dart
@@ -1,15 +1,21 @@
 /// Represents the extracted Inject annotation
 class InjectAnnotation {
+  /// The extracted value for Inject.tag
   final String? tag;
+
+  /// The extracted value for Inject.parameter.
+  final String? parameter;
 
   const InjectAnnotation({
     this.tag,
+    this.parameter,
   });
 
   /// Creates a new instance from the result of [toJson].
   factory InjectAnnotation.fromJson(Map<String, dynamic> json) {
     return InjectAnnotation(
       tag: json['tag'],
+      parameter: json['parameter'],
     );
   }
 
@@ -17,6 +23,7 @@ class InjectAnnotation {
   Map<String, dynamic> toJson() {
     return {
       'tag': tag,
+      'parameter': parameter,
     };
   }
 }

--- a/lib/src/builder/generator/service_factory/service_factory.dart
+++ b/lib/src/builder/generator/service_factory/service_factory.dart
@@ -21,7 +21,7 @@ cb.Expression buildServiceFactory(
 
   for (var param in svc.constructorArgs) {
     var defaultValue = '';
-    var parameterName = param.boundParameter ?? param.name;
+    var parameterName = param.inject?.parameter ?? param.name;
 
     var resolveWithFallbacks =
         tryResolveOrGetParameter$.call([cb.literal(parameterName)]);

--- a/lib/src/builder/generator/service_factory/service_factory.dart
+++ b/lib/src/builder/generator/service_factory/service_factory.dart
@@ -34,10 +34,7 @@ cb.Expression buildServiceFactory(
     var val = resolveWithFallbacks;
     var tag = param.inject?.tag;
     if (tag != null) {
-      val = resolveByTag$
-          .call([cb.refer('#$tag')])
-          .property('cast')
-          .call([]);
+      val = resolveByTag$.call([cb.refer('#$tag')]).property('cast').call([]);
     } else if (!param.isOptional && defaultValue.isEmpty) {
       val = resolveOrGetParameter$.call([
         serviceType,

--- a/lib/src/builder/generator/service_factory/service_factory.dart
+++ b/lib/src/builder/generator/service_factory/service_factory.dart
@@ -32,7 +32,13 @@ cb.Expression buildServiceFactory(
     }
 
     var val = resolveWithFallbacks;
-    if (!param.isOptional && defaultValue.isEmpty) {
+    var tag = param.inject?.tag;
+    if (tag != null) {
+      val = resolveByTag$
+          .call([cb.refer('#$tag')])
+          .property('cast')
+          .call([]);
+    } else if (!param.isOptional && defaultValue.isEmpty) {
       val = resolveOrGetParameter$.call([
         serviceType,
         cb.literal(param.name),

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -148,8 +148,8 @@ class PreflightBuilder implements Builder {
   }
 
   ConstructorArg _buildConstructorArg(ParameterElement param) {
-    var binding = param.metadata
-        .cast<ElementAnnotation?>()
+    var annotations = param.metadata.cast<ElementAnnotation?>();
+    var binding = annotations
         .firstWhere(
           (a) => _isLibraryAnnotation(a!, 'Parameter'),
           orElse: () => null,
@@ -165,6 +165,28 @@ class PreflightBuilder implements Builder {
       isPositional: param.isPositional,
       isNamed: param.isNamed,
       defaultValue: param.defaultValueCode ?? '',
+      inject: _extractInjectAnnotation(annotations, binding),
+    );
+  }
+
+  InjectAnnotation? _extractInjectAnnotation(
+    List<ElementAnnotation?> annotations,
+    String? binding,
+  ) {
+    var injectAnnotation = annotations.firstWhere(
+      (a) => _isLibraryAnnotation(a!, 'Inject'),
+      orElse: () => null,
+    );
+
+    if (injectAnnotation == null) {
+      return null;
+    }
+
+    var constantValue = injectAnnotation.computeConstantValue();
+    var tag = constantValue?.getField('tag')?.toSymbolValue();
+
+    return InjectAnnotation(
+      tag: tag,
     );
   }
 

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -183,10 +183,11 @@ class PreflightBuilder implements Builder {
 
     var constantValue = injectAnnotation?.computeConstantValue();
     var tag = constantValue?.getField('tag')?.toSymbolValue();
+    var parameter = constantValue?.getField('parameter')?.toStringValue();
 
     return InjectAnnotation(
       tag: tag,
-      parameter: binding
+      parameter: binding ?? parameter,
     );
   }
 

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -159,7 +159,6 @@ class PreflightBuilder implements Builder {
         ?.toStringValue();
 
     return ConstructorArg(
-      boundParameter: binding,
       name: param.name,
       isOptional: param.isOptional,
       isPositional: param.isPositional,
@@ -178,15 +177,16 @@ class PreflightBuilder implements Builder {
       orElse: () => null,
     );
 
-    if (injectAnnotation == null) {
+    if (injectAnnotation == null && binding == null) {
       return null;
     }
 
-    var constantValue = injectAnnotation.computeConstantValue();
+    var constantValue = injectAnnotation?.computeConstantValue();
     var tag = constantValue?.getField('tag')?.toSymbolValue();
 
     return InjectAnnotation(
       tag: tag,
+      parameter: binding
     );
   }
 

--- a/test/integration/integration_test.dart
+++ b/test/integration/integration_test.dart
@@ -173,4 +173,9 @@ void main() {
     var services = serviceProvider.resolveByTag(#chat);
     expect(services, isNotEmpty);
   });
+
+  test('inject tagged services', () {
+    var service = serviceProvider.resolve<Broadcaster>();
+    expect(service.transports.length, equals(2));
+  });
 }

--- a/test/unit/annotation/inject_test.dart
+++ b/test/unit/annotation/inject_test.dart
@@ -1,0 +1,11 @@
+import 'package:catalyst_builder/src/annotation/annotation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Inject constructor', () {
+    const inject = Inject(tag: #foo);
+    expect(inject, const TypeMatcher<Inject>());
+    
+    expect(inject.tag, equals(Symbol('foo')));
+  });
+}

--- a/test/unit/annotation/inject_test.dart
+++ b/test/unit/annotation/inject_test.dart
@@ -3,9 +3,10 @@ import 'package:test/test.dart';
 
 void main() {
   test('Inject constructor', () {
-    const inject = Inject(tag: #foo);
+    const inject = Inject(tag: #foo, parameter: 'bar');
     expect(inject, const TypeMatcher<Inject>());
     
     expect(inject.tag, equals(Symbol('foo')));
+    expect(inject.parameter, equals('bar'));
   });
 }

--- a/test/unit/annotation/parameter_test.dart
+++ b/test/unit/annotation/parameter_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:catalyst_builder/src/annotation/annotation.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/builder/dto/constructor_arg_test.dart
+++ b/test/unit/builder/dto/constructor_arg_test.dart
@@ -10,7 +10,6 @@ void main() {
       isOptional: true,
       isPositional: false,
       isNamed: true,
-      boundParameter: 'nullArg',
       inject: InjectAnnotation(tag: 'foo'),
     );
   });
@@ -22,7 +21,6 @@ void main() {
     expect(constructorArg.isOptional, isTrue);
     expect(constructorArg.isPositional, isFalse);
     expect(constructorArg.isNamed, isTrue);
-    expect(constructorArg.boundParameter, 'nullArg');
     expect(constructorArg.inject, isNotNull);
   });
 
@@ -36,7 +34,6 @@ void main() {
         'isNamed': true,
         'isPositional': false,
         'defaultValue': 'null',
-        'boundParameter': 'nullArg',
         'inject': containsPair('tag', 'foo'),
       }),
     );

--- a/test/unit/builder/dto/constructor_arg_test.dart
+++ b/test/unit/builder/dto/constructor_arg_test.dart
@@ -1,4 +1,4 @@
-import 'package:catalyst_builder/src/builder/dto/constructor_arg.dart';
+import 'package:catalyst_builder/src/builder/dto/dto.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -11,6 +11,7 @@ void main() {
       isPositional: false,
       isNamed: true,
       boundParameter: 'nullArg',
+      inject: InjectAnnotation(tag: 'foo'),
     );
   });
 
@@ -22,6 +23,7 @@ void main() {
     expect(constructorArg.isPositional, isFalse);
     expect(constructorArg.isNamed, isTrue);
     expect(constructorArg.boundParameter, 'nullArg');
+    expect(constructorArg.inject, isNotNull);
   });
 
   test('toJson fromJson', () {
@@ -35,6 +37,7 @@ void main() {
         'isPositional': false,
         'defaultValue': 'null',
         'boundParameter': 'nullArg',
+        'inject': {'tag': 'foo'},
       }),
     );
 

--- a/test/unit/builder/dto/constructor_arg_test.dart
+++ b/test/unit/builder/dto/constructor_arg_test.dart
@@ -37,7 +37,7 @@ void main() {
         'isPositional': false,
         'defaultValue': 'null',
         'boundParameter': 'nullArg',
-        'inject': {'tag': 'foo'},
+        'inject': containsPair('tag', 'foo'),
       }),
     );
 

--- a/test/unit/builder/dto/extracted_service_test.dart
+++ b/test/unit/builder/dto/extracted_service_test.dart
@@ -15,8 +15,7 @@ void main() {
           isOptional: true,
           isPositional: false,
           isNamed: true,
-          boundParameter: 'nullArg',
-          inject: null,
+          inject: InjectAnnotation(parameter: 'nullArg'),
         )
       ],
       service: SymbolReference(symbolName: 'foobar', library: 'baz'),

--- a/test/unit/builder/dto/extracted_service_test.dart
+++ b/test/unit/builder/dto/extracted_service_test.dart
@@ -16,6 +16,7 @@ void main() {
           isPositional: false,
           isNamed: true,
           boundParameter: 'nullArg',
+          inject: null,
         )
       ],
       service: SymbolReference(symbolName: 'foobar', library: 'baz'),

--- a/test/unit/builder/dto/inject_annotation_test.dart
+++ b/test/unit/builder/dto/inject_annotation_test.dart
@@ -6,12 +6,14 @@ void main() {
 
   setUp(() {
     annotation = InjectAnnotation(
-      tag: 'foo'
+      tag: 'foo',
+      parameter: 'bar'
     );
   });
 
   test('InjectAnnotation constructor', () {
     expect(annotation.tag, equals('foo'));
+    expect(annotation.parameter, equals('bar'));
   });
 
   test('toJson fromJson', () {
@@ -20,6 +22,7 @@ void main() {
       map,
       equals({
         'tag': 'foo',
+        'parameter': 'bar',
       }),
     );
 

--- a/test/unit/builder/dto/inject_annotation_test.dart
+++ b/test/unit/builder/dto/inject_annotation_test.dart
@@ -1,0 +1,28 @@
+import 'package:catalyst_builder/src/builder/dto/dto.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late InjectAnnotation annotation;
+
+  setUp(() {
+    annotation = InjectAnnotation(
+      tag: 'foo'
+    );
+  });
+
+  test('InjectAnnotation constructor', () {
+    expect(annotation.tag, equals('foo'));
+  });
+
+  test('toJson fromJson', () {
+    var map = annotation.toJson();
+    expect(
+      map,
+      equals({
+        'tag': 'foo',
+      }),
+    );
+
+    expect(InjectAnnotation.fromJson(map).toJson(), map);
+  });
+}

--- a/test/unit/builder/dto/preflight_part_test.dart
+++ b/test/unit/builder/dto/preflight_part_test.dart
@@ -16,8 +16,7 @@ void main() {
             isOptional: true,
             isPositional: false,
             isNamed: true,
-            boundParameter: 'nullArg',
-            inject: null,
+            inject: InjectAnnotation(parameter: 'nullArg'),
           )
         ],
         service: SymbolReference(symbolName: 'foobar', library: 'baz'),

--- a/test/unit/builder/dto/preflight_part_test.dart
+++ b/test/unit/builder/dto/preflight_part_test.dart
@@ -17,6 +17,7 @@ void main() {
             isPositional: false,
             isNamed: true,
             boundParameter: 'nullArg',
+            inject: null,
           )
         ],
         service: SymbolReference(symbolName: 'foobar', library: 'baz'),


### PR DESCRIPTION
Features:
- Introducing the new `@Inject` annotation. This annotation works like the `@Parameter` Annotation but is more flexible.
  You can use it to inject a list of tagged services and also to inject parameters. The example code contains a
  example for this feature.

Deprecations:
- The `@Parameter` annotation was marked as deprecated and will be removed in the next major release.  
  See [UPGRADE.md](UPGRADE.md) for upgrade instructions.