### PR TITLE
Do not emit empty preflight parts

### DIFF
--- a/lib/src/builder/generator/service_provider/methods/constructor.dart
+++ b/lib/src/builder/generator/service_provider/methods/constructor.dart
@@ -10,9 +10,9 @@ cb.Constructor buildProviderConstructor(
   cb.Reference typeReference,
 ) {
   return cb.Constructor((ctor) {
-    var serviceFactories = {};
-    var exposeAsData = {};
-    var servicesBySymbol = {};
+    var serviceFactories = <cb.Reference, cb.Expression>{};
+    var exposeAsData = <cb.Reference, cb.Reference>{};
+    var servicesBySymbol = <cb.Code, List<cb.Reference>>{};
     var knownTags = <String, cb.Code>{};
     for (var svc in services) {
       var serviceType = cb.refer(svc.service.symbolName, svc.service.library);
@@ -30,10 +30,13 @@ cb.Constructor buildProviderConstructor(
           knownTags[tag] = cb.Code('#$tag');
         }
         var s = knownTags[tag];
+        if (s == null) {
+          continue;
+        }
         if (!servicesBySymbol.containsKey(s)) {
           servicesBySymbol[s] = [];
         }
-        servicesBySymbol[s].add(serviceType);
+        servicesBySymbol[s]?.add(serviceType);
       }
 
       serviceFactories[serviceType] = buildServiceFactory(

--- a/lib/src/builder/preflight_builder.dart
+++ b/lib/src/builder/preflight_builder.dart
@@ -23,6 +23,9 @@ class PreflightBuilder implements Builder {
     final preflightAsset =
         buildStep.inputId.changeExtension('.catalyst_builder.preflight.json');
     var extractedAnnotations = _extractAnnotations(entryLib);
+    if (extractedAnnotations.services.isEmpty) {
+      return;
+    }
 
     await buildStep.writeAsString(
       preflightAsset,

--- a/test/integration/integration_test.dart
+++ b/test/integration/integration_test.dart
@@ -106,9 +106,9 @@ void main() {
 
   test('hasService', () {
     expect(serviceProvider.has<MySingletonService>(), isTrue);
-    expect(serviceProvider.has(MySingletonService), isTrue);
+    expect(serviceProvider.has<dynamic>(MySingletonService), isTrue);
     expect(serviceProvider.has<ChatProvider>(), isTrue);
-    expect(serviceProvider.has(ChatProvider), isTrue);
+    expect(serviceProvider.has<dynamic>(ChatProvider), isTrue);
   });
 
   test('service registration', () {


### PR DESCRIPTION
Only emit preflight results for files that contain at least one annotation