### PR TITLE
Example for relative dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,12 @@ targets:
           providerClassName: 'DefaultServiceProvider' # class name of the provider
           includePackageDependencies: false # True if services from dependencies should be added to your service provider (v1.1.0+)
 ```
+
+## Relative dependencies
+If you've dependencies to relative packages (for example if you've a monorepo) you need to export those packages in 
+the package where the service provider is generated.
+If you don't do this, the watch command will not regenerate the service provider when code changes inside the dependencies. 
+
+If you need an example, check 
+- [relative_deps_exports.dart](./example/lib/relative_deps_exports.dart)
+- [example.dart](./example/lib/example.dart) (`export 'relative_deps_exports.dart';`)

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -6,6 +6,12 @@ export './public_api.dart';
 export './src/manually_wired_service.dart';
 export 'example.catalyst_builder.g.dart';
 
+/**
+ * Export the catalyst_exports that the watch command can recompile the
+ * ServiceProvider when the dependencies changes.
+ */
+export 'relative_deps_exports.dart';
+
 @Preload()
 @GenerateServiceProvider()
 @ServiceMap(services: {

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -1,29 +1,10 @@
-library catalyst_builder_example;
-
-import 'dart:convert';
-
 import 'package:catalyst_builder/catalyst_builder.dart';
 
 import './src/manually_wired_service.dart';
 
+export './public_api.dart';
 export './src/manually_wired_service.dart';
 export 'example.catalyst_builder.g.dart';
-
-part './src/chat_provider.dart';
-
-part './src/cool_chat_provider.dart';
-
-part './src/preload_service.dart';
-
-part './src/singleton_service.dart';
-
-part './src/transient_service.dart';
-
-part './src/transport.dart';
-
-part './src/self_registered_service.dart';
-
-part './src/broadcaster.dart';
 
 @Preload()
 @GenerateServiceProvider()

--- a/example/lib/public_api.dart
+++ b/example/lib/public_api.dart
@@ -1,0 +1,16 @@
+library catalyst_builder_example;
+
+import 'dart:convert';
+
+import 'package:catalyst_builder/catalyst_builder.dart';
+
+export './src/manually_wired_service.dart';
+
+part './src/broadcaster.dart';
+part './src/chat_provider.dart';
+part './src/cool_chat_provider.dart';
+part './src/preload_service.dart';
+part './src/self_registered_service.dart';
+part './src/singleton_service.dart';
+part './src/transient_service.dart';
+part './src/transport.dart';

--- a/example/lib/relative_deps_exports.dart
+++ b/example/lib/relative_deps_exports.dart
@@ -1,0 +1,5 @@
+// If you've relative dependencies (local files) and they may change while running
+// dart run build_runner watch --delete-conflicting-outputs
+//
+// you need this helper file. Export all libraries that contains used services.
+export 'package:third_party_dependency/third_party_dependency.dart';

--- a/example/lib/src/broadcaster.dart
+++ b/example/lib/src/broadcaster.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 @Service()
 class Broadcaster implements ChatProvider {

--- a/example/lib/src/chat_provider.dart
+++ b/example/lib/src/chat_provider.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 abstract class ChatProvider {
   abstract final String username;

--- a/example/lib/src/cool_chat_provider.dart
+++ b/example/lib/src/cool_chat_provider.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 @Service(
   exposeAs: ChatProvider,

--- a/example/lib/src/preload_service.dart
+++ b/example/lib/src/preload_service.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 @Service()
 @Preload()

--- a/example/lib/src/self_registered_service.dart
+++ b/example/lib/src/self_registered_service.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 abstract class SelfRegisteredService {
   String get foo;

--- a/example/lib/src/singleton_service.dart
+++ b/example/lib/src/singleton_service.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 @Service(lifetime: ServiceLifetime.singleton)
 class MySingletonService {}

--- a/example/lib/src/transient_service.dart
+++ b/example/lib/src/transient_service.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 @Service(lifetime: ServiceLifetime.transient)
 class MyTransientService {}

--- a/example/lib/src/transport.dart
+++ b/example/lib/src/transport.dart
@@ -1,4 +1,4 @@
-part of '../example.dart';
+part of '../public_api.dart';
 
 abstract class Transport {
   void transferData(String data);

--- a/test/integration/integration_test.dart
+++ b/test/integration/integration_test.dart
@@ -2,7 +2,21 @@ import 'package:catalyst_builder/catalyst_builder.dart';
 import 'package:test/test.dart';
 
 // ignore: avoid_relative_lib_imports
-import '../../example/lib/example.dart';
+import '../../example/lib/example.catalyst_builder.g.dart';
+
+// ignore: avoid_relative_lib_imports
+import '../../example/lib/public_api.dart'
+    show
+        Broadcaster,
+        ChatProvider,
+        CoolChatProvider,
+        ManuallyWiredService,
+        ManuallyWiredServiceImplementation,
+        MySelfRegisteredService,
+        MySingletonService,
+        MyTransientService,
+        PreloadService,
+        SelfRegisteredService;
 
 // ignore: avoid_relative_lib_imports
 import '../third_party_dependency/lib/third_party_dependency.dart';


### PR DESCRIPTION
Added an example for relative dependencies.

- Created a public_api.dart to skip the relative_deps_exports.dart export
