### PR TITLE
fix: Store singleton instances in the root provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 3.5.1
+
+### Singleton instances on enhanced providers
+Previously each ServiceProvider had a map of service instances. If a singleton was created, the provider stored the 
+instance in the map and returned the instance the next time it is requested.
+
+If you're working with enhanced providers (`ServiceProvider.enhance`), the singletons created in the EnhancedProvider 
+ wasn't stored in the root provider which causes that a singleton will be created again if it's resolved in the root
+provider.
+
+To solve this problem, the instances of the map is now a reference to the original instances map of the parent provider.
+
+
 ## 3.5.0
 
 Updated the version constraint of the analyzer package.

--- a/lib/src/builder/generator/service_provider/fields/service_instances.dart
+++ b/lib/src/builder/generator/service_provider/fields/service_instances.dart
@@ -6,6 +6,5 @@ import '../../symbols.dart';
 final serviceInstancesTemplate = cb.Field((f) {
   f
     ..name = serviceInstances$.symbol
-    ..modifier = cb.FieldModifier.final$
     ..assignment = cb.literalMap({}, typeT, dynamicT).code;
 });

--- a/lib/src/builder/generator/service_provider/methods/enhance.dart
+++ b/lib/src/builder/generator/service_provider/methods/enhance.dart
@@ -46,8 +46,8 @@ cb.Method enhanceTemplate(String providerClassName) {
         initVar(enhancedV, cb.refer(providerClassName).newInstance([])),
         enhancedV
             .property(serviceInstances$.symbol!)
-            .property('addAll')
-            .call([serviceInstances$]).statement,
+            .assign(serviceInstances$)
+            .statement,
         _addKnownServices(enhancedV),
         enhancedV
             .property(exposeMap$.symbol!)

--- a/test/integration/integration_test.dart
+++ b/test/integration/integration_test.dart
@@ -277,4 +277,18 @@ void main() {
         enhanced.resolve<ServiceThatDependOnEnhancedService>().dependency.foo,
         equals('bar'));
   });
+
+  test('enhance should register singletons in the root provider', () {
+    if (serviceProvider is! EnhanceableProvider) {
+      fail('Service provider is not a EnhanceableProvider');
+    }
+
+    var enhanced1 = (serviceProvider as EnhanceableProvider).enhance();
+    expect(enhanced1.resolve<SingletonThatShouldBeRegisteredInRoot>().count,
+        equals(1));
+
+    var enhanced2 = (serviceProvider as EnhanceableProvider).enhance();
+    expect(enhanced2.resolve<SingletonThatShouldBeRegisteredInRoot>().count,
+        equals(1));
+  });
 }

--- a/test/third_party_dependency/lib/third_party_dependency.dart
+++ b/test/third_party_dependency/lib/third_party_dependency.dart
@@ -13,3 +13,14 @@ class ServiceThatDependOnEnhancedService {
 class ServiceOnlyProvidedInEnhanced {
   final String foo = 'bar';
 }
+
+@Service()
+class SingletonThatShouldBeRegisteredInRoot {
+  static var _count = 0;
+
+  int get count => _count;
+
+  SingletonThatShouldBeRegisteredInRoot() {
+    _count++;
+  }
+}


### PR DESCRIPTION
Previously each ServiceProvider had a map of service instances. If a singleton was created, the provider stored the instance in the map and returned the instance the next time it is requested.

If you're working with enhanced providers (`ServiceProvider.enhance`), the singletons created in the EnhancedProvider
 wasn't stored in the root provider which causes that a singleton will be created again if it's resolved in the root
provider.

To solve this problem, the instances of the map is now a reference to the original instances map of the parent provider.