### PR TITLE
fix: update the generated provider file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 3.6.0
+
+### Fixed updating the generated provider file
+In this release we hopefully fixed the old problem with outdated `*.catalyst_builder.g.dart` files.
+
+#### Cause
+The ServiceProviderBuilder did not emit an updated version since the `@GenerateServiceProvider` annotation 
+doesn't exist in the most files. 
+
+#### Solution
+We added a new `generatedProviderFile` option to the preflightBuilder configuration. You need to put the relative path
+to the generated provider file (`*.catalyst_builder.g.dart`) in this option.
+The PreflightBuilder will automatically delete the file if it exists. This lead to a full regeneration of the service
+provider file. 🙌
+
 ## 3.5.2
 
 ### Fix downgrade error

--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ targets:
   $default:
     auto_apply_builders: true
     builders:
+      catalyst_builder|preflight:
+        options:
+          generatedProviderFile: 'lib/main.catalyst_builder.g.dart' # Enter the path to the generated service provider file
+                                                                    # This ensures that the file is reliably updated.
       catalyst_builder|buildServiceProvider:
         options:
           providerClassName: 'DefaultServiceProvider' # class name of the provider

--- a/build.yaml
+++ b/build.yaml
@@ -6,6 +6,9 @@ builders:
     build_extensions: { '.dart': [ '.catalyst_builder.preflight.json' ] }
     build_to: cache
     auto_apply: dependents
+    defaults:
+      options:
+        generatedProviderFile: ''
 
   buildServiceProvider:
     import: 'package:catalyst_builder/src/builder/service_provider_builder.dart'

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -2,6 +2,9 @@ targets:
   $default:
     auto_apply_builders: true
     builders:
+      catalyst_builder|preflight:
+        options:
+          generatedProviderFile: 'lib/example.catalyst_builder.g.dart'
       catalyst_builder|buildServiceProvider:
         options:
           providerClassName: 'ExampleProvider'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: catalyst_builder
 description: A lightweight and easy to use dependency injection provider builder for dart.
-version: 3.5.2
+version: 3.6.0
 homepage: 'https://github.com/mintware-de/catalyst_builder'
 repository: 'https://github.com/mintware-de/catalyst_builder'
 


### PR DESCRIPTION
Cause
The ServiceProviderBuilder did not emit an updated version since the `@GenerateServiceProvider` annotation doesn't exist in newly created files.

Solution
We added a new `generatedProviderFile` option to the preflightBuilder configuration. You need to put the relative path to the generated provider file (`*.catalyst_builder.g.dart`) in this option. The PreflightBuilder will automatically delete the file if it exists. This lead to a full regeneration of the service provider file. 🙌