### PR TITLE
Migrate to post_process_builders

### DIFF
--- a/packages/catalyst_builder/CHANGELOG.md
+++ b/packages/catalyst_builder/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 4.3.0
+
+### Fixes
+
+#### Skip unprocessable files
+This will fix the following error when using catalyst_builder with Flutter:
+```plain
+[SEVERE] catalyst_builder:preflight on package:sky_engine/html/html_dart2js.dart:
+
+This builder requires Dart inputs without syntax errors.
+...
+```
+
+
 ## 4.2.1
 
 ### Fixes

--- a/packages/catalyst_builder/CHANGELOG.md
+++ b/packages/catalyst_builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 4.3.0
 
+### Changes
+
+#### Migrated the ServiceProviderBuilder to post_process_builders
+Since the ServiceProviderBuilder does not rely on the real outputs of the previous builders but the cache files,
+this is a much better solution since a PostProcessBuilders does not process all .dart files.
+
 ### Fixes
 
 #### Skip unprocessable files

--- a/packages/catalyst_builder/build.yaml
+++ b/packages/catalyst_builder/build.yaml
@@ -7,6 +7,8 @@ builders:
       '.dart': [ '.catalyst_builder.entrypoint.json' ]
     build_to: cache
     auto_apply: root_package
+    runs_before:
+      - 'catalyst_builder:preflight'
   preflight:
     import: 'package:catalyst_builder/src/builder/builders.dart'
     builder_factories:
@@ -17,15 +19,10 @@ builders:
     auto_apply: all_packages
     required_inputs:
       - '.catalyst_builder.entrypoint.json'
+    applies_builders:
+      - 'catalyst_builder:buildServiceProvider'
+post_process_builders:
   buildServiceProvider:
     import: 'package:catalyst_builder/src/builder/builders.dart'
-    builder_factories:
-      - 'createServiceProviderBuilder'
-    build_extensions:
-      '.catalyst_builder.entrypoint.json': [ '.catalyst_builder.g.dart' ]
-    build_to: source
-    auto_apply: root_package
-    required_inputs:
-      - '.catalyst_builder.entrypoint.json'
-
-
+    builder_factory: 'createServiceProviderBuilder'
+    input_extensions: [".catalyst_builder.entrypoint.json", '.catalyst_builder.preflight.json']

--- a/packages/catalyst_builder/lib/src/builder/builders.dart
+++ b/packages/catalyst_builder/lib/src/builder/builders.dart
@@ -11,5 +11,5 @@ Builder createEntrypointBuilder(BuilderOptions options) => EntrypointBuilder();
 Builder createPreflightBuilder(BuilderOptions options) => PreflightBuilder();
 
 /// Creates the service provider builder
-Builder createServiceProviderBuilder(BuilderOptions options) =>
+PostProcessBuilder createServiceProviderBuilder(BuilderOptions options) =>
     ServiceProviderBuilder();

--- a/packages/catalyst_builder/lib/src/builder/entrypoint_builder.dart
+++ b/packages/catalyst_builder/lib/src/builder/entrypoint_builder.dart
@@ -22,7 +22,13 @@ class EntrypointBuilder implements Builder {
     if (!await buildStep.resolver.isLibrary(buildStep.inputId)) {
       return;
     }
-    var libraryElement = (await buildStep.inputLibrary);
+    LibraryElement libraryElement;
+    try {
+      libraryElement = (await buildStep.inputLibrary);
+    } catch (e) {
+      log.warning('Error while processing input library. Skip for now.', e);
+      return;
+    }
 
     var annotation = libraryElement.topLevelElements
         .map((el) => el.metadata

--- a/packages/catalyst_builder/lib/src/builder/preflight_builder.dart
+++ b/packages/catalyst_builder/lib/src/builder/preflight_builder.dart
@@ -49,6 +49,10 @@ class PreflightBuilder implements Builder {
       cachedPath,
       jsonEncode(extractedAnnotations),
     );
+    buildStep.writeAsString(
+      buildStep.inputId.changeExtension(preflightExtension),
+      jsonEncode(extractedAnnotations),
+    );
   }
 
   String _getFilename(BuildStep buildStep) {

--- a/packages/catalyst_builder/lib/src/builder/preflight_builder.dart
+++ b/packages/catalyst_builder/lib/src/builder/preflight_builder.dart
@@ -30,9 +30,14 @@ class PreflightBuilder implements Builder {
       return;
     }
 
-    var extractedAnnotations = _extractAnnotations(
-      await buildStep.inputLibrary,
-    );
+    LibraryElement libraryElement;
+    try {
+      libraryElement = await buildStep.inputLibrary;
+    } catch (e) {
+      log.warning('Error while processing input library. Skip for now.', e);
+      return;
+    }
+    var extractedAnnotations = _extractAnnotations(libraryElement);
 
     final cachedPath = _getFilename(buildStep);
     if (extractedAnnotations.services.isEmpty) {

--- a/packages/catalyst_builder/lib/src/cache_helper.dart
+++ b/packages/catalyst_builder/lib/src/cache_helper.dart
@@ -8,8 +8,11 @@ import './builder/constants.dart';
 import './builder/dto/dto.dart';
 
 final class CacheHelper {
-  static const _filePattern = '**/*$preflightExtension';
-  static final _preflightFiles = Glob(_filePattern, recursive: true);
+  static const _preflightFilePattern = '**/*$preflightExtension';
+  static final _preflightFiles = Glob(_preflightFilePattern, recursive: true);
+
+  static const _entrypointFilePattern = '**/*$entrypointExtension';
+  static final _entrypointFiles = Glob(_entrypointFilePattern, recursive: true);
 
   /// Returns the path to the cache directory
   late final String _cachePath;
@@ -26,8 +29,11 @@ final class CacheHelper {
   Stream<FileSystemEntity> get preflightFiles =>
       _preflightFiles.list(root: _cachePath);
 
+  Stream<FileSystemEntity> get entrypointFiles =>
+      _entrypointFiles.list(root: _cachePath);
+
   Stream<FileSystemEntity> getPreflightFilesForPackage(String package) {
-    return Glob('$package/$_filePattern', recursive: true)
+    return Glob('$package/$_preflightFilePattern', recursive: true)
         .list(root: _cachePath);
   }
 

--- a/packages/catalyst_builder/pubspec.yaml
+++ b/packages/catalyst_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: catalyst_builder
 description: A lightweight and easy to use dependency injection provider builder for dart.
-version: 4.2.1
+version: 4.3.0
 homepage: 'https://github.com/mintware-de/catalyst_builder'
 repository: 'https://github.com/mintware-de/catalyst_builder/tree/main/packages/catalyst_builder'
 documentation: https://github.com/mintware-de/catalyst_builder/wiki


### PR DESCRIPTION
### Changes

#### Migrated the ServiceProviderBuilder to post_process_builders
Since the ServiceProviderBuilder does not rely on the real outputs of the previous builders but the cache files,
this is a much better solution since a PostProcessBuilders does not process all .dart files.

### Fixes

#### Skip unprocessable files
This will fix the following error when using catalyst_builder with Flutter:
```plain
[SEVERE] catalyst_builder:preflight on package:sky_engine/html/html_dart2js.dart:

This builder requires Dart inputs without syntax errors.
...
```