### PR TITLE
add new catalystServices builder

### DIFF
--- a/packages/catalyst_builder/build.yaml
+++ b/packages/catalyst_builder/build.yaml
@@ -9,8 +9,10 @@ builders:
     auto_apply: root_package
     runs_before:
       - 'catalyst_builder:buildServiceContainerPlugin'
+      - 'catalyst_builder:buildCatalystLibrary'
     applies_builders:
       - 'catalyst_builder:buildServiceContainerPlugin'
+      - 'catalyst_builder:buildCatalystLibrary'
 
   buildServiceContainerPlugin:
     import: 'package:catalyst_builder/src/builder/builders.dart'
@@ -19,5 +21,15 @@ builders:
     build_extensions: { '.dart': [ '.catalyst_builder.plugin.g.dart' ] }
     build_to: source
     auto_apply: dependents
+    required_inputs:
+      - '.catalyst_builder.preflight.json'
+
+  buildCatalystLibrary:
+    import: 'package:catalyst_builder/src/builder/builders.dart'
+    builder_factories:
+      - 'createCatalystLibraryBuilder'
+    build_extensions: { '.dart': [ '.catalyst_library.g.dart' ] }
+    build_to: source
+    auto_apply: root_package
     required_inputs:
       - '.catalyst_builder.preflight.json'

--- a/packages/catalyst_builder/lib/src/builder/builders.dart
+++ b/packages/catalyst_builder/lib/src/builder/builders.dart
@@ -1,5 +1,6 @@
 import 'package:build/build.dart';
 
+import 'catalyst_library_builder.dart';
 import 'preflight_builder.dart';
 import 'service_container_plugin_builder.dart';
 
@@ -9,3 +10,7 @@ Builder createPreflightBuilder(BuilderOptions options) => PreflightBuilder();
 /// Creates the service container plugin builder
 Builder createServiceContainerPluginBuilder(BuilderOptions options) =>
     ServiceContainerPluginBuilder();
+
+/// Creates the catalyst library builder
+Builder createCatalystLibraryBuilder(BuilderOptions options) =>
+    CatalystLibraryBuilder();

--- a/packages/catalyst_builder/lib/src/builder/catalyst_library_builder.dart
+++ b/packages/catalyst_builder/lib/src/builder/catalyst_library_builder.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:glob/glob.dart';
+
+import 'constants.dart';
+import 'dto/dto.dart';
+import 'generator/service_library/service_library.dart';
+import 'helpers.dart';
+
+/// The CatalystLibraryBuilder creates a library file that exports
+/// all services in the current package as a Map.
+class CatalystLibraryBuilder implements Builder {
+  @override
+  FutureOr<void> build(BuildStep buildStep) async {
+    if (!await buildStep.resolver.isLibrary(buildStep.inputId)) {
+      return;
+    }
+    LibraryElement libraryElement;
+    try {
+      libraryElement = (await buildStep.inputLibrary);
+    } catch (e) {
+      log.warning('Error while processing input library. Skip for now.', e);
+      return;
+    }
+
+    var annotation = libraryElement.metadata
+        .where((m) => m.isLibraryAnnotation('GenerateCatalystLibrary'))
+        .firstOrNull;
+
+    var isEntryPoint = annotation != null;
+    if (!isEntryPoint) {
+      return;
+    }
+
+    var constantValue = annotation.computeConstantValue()!;
+    var libraryName =
+        constantValue.getField('libraryName')?.toStringValue() ?? 'catalystServices';
+    var includeDependencies =
+        constantValue.getField('includeDependencies')?.toBoolValue() ?? false;
+
+    var content = await _generateCode(buildStep, libraryName, includeDependencies);
+    await buildStep.writeAsString(
+      buildStep.inputId.changeExtension(catalystLibraryExtension),
+      content,
+    );
+  }
+
+  Future<String> _generateCode(
+      BuildStep buildStep, String libraryName, bool includeDependencies) async {
+    final parts = <PreflightPart>[];
+    final services = <ExtractedService>[];
+
+    await for (final input
+        in buildStep.findAssets(Glob('**/**$preflightExtension'))) {
+      final jsonContent = await buildStep.readAsString(input);
+      final part = PreflightPart.fromJson(
+        jsonDecode(jsonContent) as Map<String, dynamic>,
+      );
+      parts.add(part);
+      
+      // If includeDependencies is false, only include services from current package
+      if (!includeDependencies) {
+        final currentPackage = buildStep.inputId.package;
+        final packageServices = part.services.where((service) {
+          return service.service.library?.startsWith('package:$currentPackage/') == true;
+        }).toList();
+        services.addAll(packageServices);
+      } else {
+        services.addAll(part.services);
+      }
+    }
+
+    final emitter = DartEmitter.scoped(
+      orderDirectives: true,
+      useNullSafetySyntax: true,
+    );
+
+    final rawOutput = Library(
+      (l) => l.body.addAll([
+        buildServicesMap(libraryName, services),
+      ]),
+    ).accept(emitter).toString();
+
+    var content =
+        DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+            .format('''
+// ignore_for_file: prefer_relative_imports, public_member_api_docs, implementation_imports
+    $rawOutput
+    ''');
+    
+    // Replace final with const and remove const from Service instances
+    content = content
+        .replaceAll('final Map<Type, _i1.Service> $libraryName', 'const Map<Type, _i1.Service> $libraryName')
+        .replaceAll('const _i1.Service()', '_i1.Service()');
+    
+    return content;
+  }
+
+  @override
+  Map<String, List<String>> get buildExtensions => {
+        r'$lib$': [],
+        r'.dart': [catalystLibraryExtension],
+      };
+}

--- a/packages/catalyst_builder/lib/src/builder/constants.dart
+++ b/packages/catalyst_builder/lib/src/builder/constants.dart
@@ -2,5 +2,6 @@ const String preflightExtension = '.catalyst_builder.preflight.json';
 const String oldAnnotationsPrefix = 'package:catalyst_builder/src/annotation/';
 const String serviceContainerPluginExtension =
     '.catalyst_builder.plugin.g.dart';
+const String catalystLibraryExtension = '.catalyst_library.g.dart';
 const String annotationsPrefix =
     'package:catalyst_builder_contracts/src/annotation/';

--- a/packages/catalyst_builder/lib/src/builder/generator/service_library/service_library.dart
+++ b/packages/catalyst_builder/lib/src/builder/generator/service_library/service_library.dart
@@ -1,0 +1,24 @@
+import 'package:code_builder/code_builder.dart' as cb;
+
+import '../../dto/dto.dart';
+import '../symbols.dart';
+
+/// Builds the services map for the library
+cb.Field buildServicesMap(String libraryName, List<ExtractedService> services) {
+  final mapEntries = <cb.Expression, cb.Expression>{};
+
+  for (final service in services) {
+    final serviceType =
+        cb.refer(service.service.symbolName, service.service.library);
+    final serviceInstance = cb.CodeExpression(cb.Code('_i1.Service()'));
+
+    mapEntries[serviceType] = serviceInstance;
+  }
+
+  return cb.Field((f) => f
+    ..name = libraryName
+    ..type = mapOfT(typeT, serviceT)
+    ..modifier = cb.FieldModifier.constant
+    ..assignment = cb.literalMap(mapEntries).code);
+}
+

--- a/packages/catalyst_builder_contracts/lib/src/annotation/annotation.dart
+++ b/packages/catalyst_builder_contracts/lib/src/annotation/annotation.dart
@@ -1,3 +1,4 @@
+export 'generate_catalyst_library.dart';
 export 'generate_service_container_plugin.dart';
 export 'inject.dart';
 export 'preload.dart';

--- a/packages/catalyst_builder_contracts/lib/src/annotation/generate_catalyst_library.dart
+++ b/packages/catalyst_builder_contracts/lib/src/annotation/generate_catalyst_library.dart
@@ -1,0 +1,17 @@
+/// Mark the file which contains this annotation to generate a library
+/// that exports all services in the current package.
+class GenerateCatalystLibrary {
+  /// Set this property for setting the variable name of the generated
+  /// services map.
+  final String libraryName;
+
+  /// Set this property to include services from dependencies.
+  /// By default, only services from the current package are included.
+  final bool includeDependencies;
+
+  /// Mark this file to generate a services library
+  const GenerateCatalystLibrary({
+    this.libraryName = 'catalystServices',
+    this.includeDependencies = false,
+  });
+}


### PR DESCRIPTION
The new builder makes it easier to use outer services, ie:

```dart
// /lib/services.dart

@GenerateCatalystLibrary()
library;

import 'package:catalyst_builder_contracts/catalyst_builder_contracts.dart';
```

Will generate something like 

```dart
// ignore_for_file: prefer_relative_imports, public_member_api_docs, implementation_imports
// ignore_for_file: no_leading_underscores_for_library_prefixes
import 'package:catalyst_builder_contracts/catalyst_builder_contracts.dart'
    as _i1;
import 'package:foo.dart' as _i3;

const Map<Type, _i1.Service> catalystServices = {
  _i3.Foo: _i1.Service(),
};

```

Which then can be used in another project like 

```dart
import 'package:catalyst_builder/catalyst_builder.dart';
import 'package:foo/services.catalyst_library.g.dart' as models;

import 'main.catalyst_builder.plugin.g.dart';

@ServiceMap(services: {
  ...models.catalystServices// you can concatenate the generated map instead of registering every service
})
@GenerateServiceContainerPlugin(
  pluginClassName: 'Foooo',
)
Future<void> main(List<String> args) async {
...
}

```