### PR TITLE
feat: Allow passing a runtime type to resolve and tryResolve

### DIFF
--- a/packages/catalyst_builder_contracts/CHANGELOG.md
+++ b/packages/catalyst_builder_contracts/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.0
+
+### Features
+
+Added an optional `[Type? t]` parameter to: 
+- `AbstractServiceContainer.resolve<T>([Type? t])` 
+- `AbstractServiceContainer.tryResolve<T>([Type? t])`
+
+This is helpful for dynamic type resolution on runtime
+
 ## 2.0.0
 
 No additional changes were made. Check changes of previous version.

--- a/packages/catalyst_builder_contracts/lib/src/abstract_service_container.dart
+++ b/packages/catalyst_builder_contracts/lib/src/abstract_service_container.dart
@@ -8,18 +8,18 @@ abstract interface class AbstractServiceContainer {
   /// parameter and the type matches the expected type, this parameter is used.
   Map<String, dynamic> get parameters;
 
-  /// Resolves a [Service] of the given [T]ype.
-  ///
+  /// Resolves a [Service] of the given [t]type or [T]ype.
+  /// If [t] is provided, [t] must be castable to [T]
   /// If the service does not exist, an [Exception] is thrown.
-  T resolve<T>();
+  T resolve<T>([Type? t]);
 
   /// Resolves all registered services with the given [tag].
   List<dynamic> resolveByTag(Symbol tag);
 
-  /// Try to resolve a [Service] of the given [T]ype.
+  /// Try to resolve a [Service] of the given [t]type or [T]ype.
   ///
   /// If the service does not exist, null is returned.
-  T? tryResolve<T>();
+  T? tryResolve<T>([Type? t]);
 
   /// Checks if a with the [T] or [type] is registered.
   bool has<T>([Type? type]);
@@ -43,6 +43,8 @@ abstract interface class AbstractServiceContainer {
   ]);
 
   /// Try to resolve a service of the type [T].
+  /// If [t] is provided, [t] must be castable to [T]
+  ///
   /// If there is no matching service, try to resolve a [parameter] of the type
   /// [T]. If no parameter exists, return null;
   T? tryResolveOrGetParameter<T>(String parameter);

--- a/packages/catalyst_builder_contracts/pubspec.yaml
+++ b/packages/catalyst_builder_contracts/pubspec.yaml
@@ -1,6 +1,6 @@
 name: catalyst_builder_contracts
 description: This is the contracts package for the catalyst_builder package. It includes annotations and marker interfaces.
-version: 2.0.0
+version: 2.1.0
 homepage: 'https://github.com/mintware-de/catalyst_builder'
 repository: 'https://github.com/mintware-de/catalyst_builder/tree/main/packages/catalyst_builder_contracts'
 documentation: https://github.com/mintware-de/catalyst_builder/wiki


### PR DESCRIPTION

Added an optional `[Type? t]` parameter to:
- `AbstractServiceContainer.resolve<T>([Type? t])`
- `AbstractServiceContainer.tryResolve<T>([Type? t])`

This is helpful for dynamic type resolution on runtime

Example:

```dart

  const Type p = ChatProvider;
  // works
  container.resolve<ChatProvider>(p);

  // fails because ChatProvider is not a Broadcaster
  try {
    container.resolve<Broadcaster>(p);
  } catch (_) {
  }
```